### PR TITLE
chore: upgrade Java to 17 for modern build environments

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,12 +40,12 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,15 @@ subprojects {
                 if (namespace == null) {
                     namespace project.group
                 }
+                compileOptions {
+                    sourceCompatibility JavaVersion.VERSION_17
+                    targetCompatibility JavaVersion.VERSION_17
+                }
+            }
+            project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                kotlinOptions {
+                    jvmTarget = "17"
+                }
             }
         }
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4096M
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false


### PR DESCRIPTION
This PR upgrades the project configuration to use Java 17.
This is a short-term fix required to successfully build the application on newly installed development environments where Java 1.8 is no longer viable.

Note: In the near future, a deeper dependency overhaul will be necessary due to incoming Flutter warnings regarding the deprecation of current Gradle (8.11.1), AGP (8.10.0), and Kotlin (2.1.21) versions, alongside the required migration to Built-in Kotlin.
Changes:

    Upgraded Java compiler/target version to 17 in the build configuration.

Type of Change

    [x] ⚙️ Chore / Build environment fix

Testing

    [x] Verified that the project builds successfully on clean, modern development setups.