### PR TITLE
feat: add dynamic my-location button with map centering logic

### DIFF
--- a/lib/bloc/location/location_cubit.dart
+++ b/lib/bloc/location/location_cubit.dart
@@ -9,7 +9,7 @@ class LocationCubit extends Cubit<LocationState> {
   final GeolocationRepository geolocationRepository;
 
   Future<void> locate() async {
-    if (state is LocationReady) {
+    if (state is! LocationDetermining) {
       emit(LocationDetermining());
       var result = await geolocationRepository.locate();
       emit(LocationDetermined(

--- a/lib/screens/map/map_screen.dart
+++ b/lib/screens/map/map_screen.dart
@@ -106,7 +106,7 @@ class _MapScreenState extends State<MapScreen> {
                   panelBuilder: (ScrollController sc) => Container(
                       decoration: BoxDecoration(borderRadius: radius),
                       child: BottomPanel(scrollController: sc)),
-                  body: const RasterMap()),
+                  body: RasterMap(floatingPanelPosition: _floatingPanelPosition)),
               const MapHeader(),
               FloatingPanel(floatingPanelPosition: _floatingPanelPosition),
               const MarkerSelectionFooter()

--- a/lib/screens/map/raster_map.dart
+++ b/lib/screens/map/raster_map.dart
@@ -233,10 +233,7 @@ class _RasterMapState extends State<RasterMap> with TickerProviderStateMixin {
                           child: GestureDetector(
                             behavior: HitTestBehavior.translucent,
                             onTap: () {
-                              var locState = context.read<LocationCubit>().state;
-                              if (locState is LocationDetermined) {
-                                _animatedMapMove(locState.center, 18);
-                              }
+                              context.read<LocationCubit>().locate();
                             },
                             child: Card(
                               color: CupertinoColors.secondarySystemBackground

--- a/lib/screens/map/raster_map.dart
+++ b/lib/screens/map/raster_map.dart
@@ -3,6 +3,7 @@ import 'package:aed_map/bloc/edit/edit_state.dart';
 import 'package:aed_map/bloc/routing/routing_cubit.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_location_marker/flutter_map_location_marker.dart';
@@ -20,7 +21,9 @@ import '../../shared/cached_network_tile_provider.dart';
 import '../../shared/utils.dart';
 
 class RasterMap extends StatefulWidget {
-  const RasterMap({super.key});
+  const RasterMap({super.key, required this.floatingPanelPosition});
+
+  final double floatingPanelPosition;
 
   @override
   State<RasterMap> createState() => _RasterMapState();
@@ -222,6 +225,34 @@ class _RasterMapState extends State<RasterMap> with TickerProviderStateMixin {
                         }
                         return Container();
                       }),
+                      Positioned(
+                        right: 16,
+                        bottom: 116 + (widget.floatingPanelPosition * 340),
+                        child: SafeArea(
+                          maintainBottomViewPadding: true,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.translucent,
+                            onTap: () {
+                              var locState = context.read<LocationCubit>().state;
+                              if (locState is LocationDetermined) {
+                                _animatedMapMove(locState.center, 18);
+                              }
+                            },
+                            child: Card(
+                              color: CupertinoColors.secondarySystemBackground
+                                  .resolveFrom(context),
+                              child: Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: Icon(
+                                  CupertinoIcons.location,
+                                  color:
+                                      CupertinoColors.label.resolveFrom(context),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
                     ],
                   )),
                 ],
@@ -237,6 +268,15 @@ class _RasterMapState extends State<RasterMap> with TickerProviderStateMixin {
     if (!isMapInitialized) {
       return;
     }
+
+    final distance = const Distance().as(
+        LengthUnit.Kilometer, mapController.camera.center, destLocation);
+
+    if (distance > 50) {
+      mapController.move(destLocation, destZoom);
+      return;
+    }
+
     final latTween = Tween<double>(
         begin: mapController.camera.center.latitude,
         end: destLocation.latitude);


### PR DESCRIPTION
This Pull Request introduces a dedicated "My Location" floating button to the map interface. It allows users to quickly center the camera view back onto their current geographic position.
Key Changes & Technical Implementation
    Connected the UI button to the existing location tracking controller/stream.

    Implemented the necessary boilerplate and callback routing between the presentation layer (Widget) and the map controller (MapController or equivalent instance) to programmatically trigger camera movements.

<img width="1200" height="2670" alt="Screenshot_2026-05-23-11-49-33-048_pl enteam aed_map" src="https://github.com/user-attachments/assets/9200fc2e-3fd1-4d04-8321-aef10f6d1888" />
<img width="1200" height="2670" alt="Screenshot_2026-05-23-11-49-31-633_pl enteam aed_map" src="https://github.com/user-attachments/assets/84cf87be-13c4-482d-b6b5-240f4ebdae02" />

