### PR TITLE
fix: add mounted guard before setState() in async SharedPreferences callback

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -84,6 +84,7 @@ class _AppState extends State<App> {
   void initState() {
     super.initState();
     SharedPreferences.getInstance().then((prefs) {
+      if (!mounted) return;
       setState(() {
         if (!prefs.containsKey('onboarded')) {
           home = OnboardingScreen();


### PR DESCRIPTION
Adds a `mounted` check before `setState()` in `_AppState.initState()` to prevent calling `setState()` on a disposed widget if the `SharedPreferences.getInstance()` future resolves after the widget is unmounted.

## Change

One line added in `lib/main.dart`:

```dart
SharedPreferences.getInstance().then((prefs) {
  if (!mounted) return;   // added
  setState(() { ... });
});
```

## Testing

Tested on Pixel 6, Android 16.

Fixes #43