### PR TITLE
ci: add coverage reporting and CI/coverage badges to README (#42)

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -10,22 +10,27 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
       - name: Install dependencies
         run: flutter pub get
-      - name: Run tests
-        run: flutter test
+      - name: Run tests with coverage
+        run: flutter test --coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage/lcov.info
+          fail_ci_if_error: false
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
       - name: Install dependencies
         run: flutter pub get
-      - name: Analyze project source
+      - name: Analyse project source
         run: flutter analyze

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@
 <img src="assets/screenshot.png" alt="Mapa AED" width="60%">
 </p>
 
+<p align="center">
+  <a href="https://github.com/matisiekpl/aed_map/actions/workflows/flutter.yml">
+    <img src="https://github.com/matisiekpl/aed_map/actions/workflows/flutter.yml/badge.svg" alt="CI">
+  </a>
+  <a href="https://codecov.io/gh/matisiekpl/aed_map">
+    <img src="https://codecov.io/gh/matisiekpl/aed_map/branch/main/graph/badge.svg" alt="Coverage">
+  </a>
+</p>
+
 ## Funkcjonalności
 
 * Wyświetlanie defibrylatorów na mapie Polski


### PR DESCRIPTION
## Summary

Fixes #42.

- Adds `--coverage` flag to `flutter test` so `coverage/lcov.info` is generated on every CI run.
- Uploads the report to Codecov via `codecov/codecov-action@v5`. `fail_ci_if_error: false` means CI continues to pass even before the `CODECOV_TOKEN` secret is configured.
- Adds CI status and Codecov badges to README, below the screenshot.
- Bumps `actions/checkout` v3 → v4 and keeps `subosito/flutter-action@v2`.

**To activate the coverage badge:** add `CODECOV_TOKEN` as a repository secret at Settings → Secrets and variables → Actions, using the token from [codecov.io/gh/matisiekpl/aed_map](https://codecov.io/gh/matisiekpl/aed_map).

## Test plan

- [x] CI workflow syntax valid
- [x] `flutter test --coverage` runs locally and produces `coverage/lcov.info`

Closes #42